### PR TITLE
Create 50-adguardhome.conf

### DIFF
--- a/root/etc/sysctl.d/50-adguardhome.conf
+++ b/root/etc/sysctl.d/50-adguardhome.conf
@@ -1,0 +1,3 @@
+# quic-go expects larger UDP send/receive buffers
+net.core.rmem_max = 7500000
+net.core.wmem_max = 7500000


### PR DESCRIPTION
quic-go expects larger UDP send/receive buffers